### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,54 @@
+name: Bug or Incompatibility
+description: Report bugs or other behavior related issues here.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before reporting a crash here, please make sure you are on the latest version.
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: What you expected to see.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Observed/Actual behavior
+      description: What you actually saw.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps/models to reproduce
+      description: This may include a screenshot, a video, or detailed instructions to help reconstruct the issue.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Version
+      description: Please provide the version of the mod you're running. This can be found in the file name of the mod jar.
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Agreements
+      description: Please agree to the following.
+      options:
+        - label: I am running the latest version of the mod.
+          required: true
+        - label: I have searched for and ensured there isn't already an open issue regarding this.
+          required: true
+        - label: My version of Minecraft is supported.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Other
+      description: |
+        Please include other helpful information below.
+        The more information we receive, the quicker and more effective we can be at finding the solution to the issue.
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,10 +1,10 @@
-name: Bug or Incompatibility
-description: Report bugs or other behavior related issues here.
+name: Bug Report
+description: Report a bug
 body:
   - type: markdown
     attributes:
       value: |
-        Before reporting a crash here, please make sure you are on the latest version.
+        Before reporting a crash here, please make sure you are on the latest supported version.
 
   - type: textarea
     attributes:
@@ -12,18 +12,21 @@ body:
       description: What you expected to see.
     validations:
       required: true
+
   - type: textarea
     attributes:
-      label: Observed/Actual behavior
+      label: Observed/actual behavior
       description: What you actually saw.
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Steps/models to reproduce
       description: This may include a screenshot, a video, or detailed instructions to help reconstruct the issue.
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Version
@@ -38,17 +41,16 @@ body:
       options:
         - label: I am running the latest version of the mod.
           required: true
-        - label: I have searched for and ensured there isn't already an open issue regarding this.
-          required: true
         - label: My version of Minecraft is supported.
+          required: true
+        - label: I have searched for and ensured there isn't already an open issue regarding this.
           required: true
 
   - type: textarea
     attributes:
       label: Other
       description: |
-        Please include other helpful information below.
+        Please include other information that may be helpful below.
         The more information we receive, the quicker and more effective we can be at finding the solution to the issue.
     validations:
       required: false
-

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: true
+contact_links:
+  - name: [fullname]
+    url: mailto://[email]
+    about: Please direct critical enquiries here.
+  - name: The Fabric Project
+    url: https://discord.gg/v6v4pMv
+    about: Please ask and answer questions related to Fabric here.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,45 @@
+name: Feature Request
+description: Suggest an idea
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for filling out a feature request! Please be as detailed as possible so that we may consider and review the request easier.
+        We ask that you search all the issues to avoid a duplicate feature request. If one exists, please reply if you have anything to add.
+        Before requesting a new feature, please make sure you are using the latest version and that the feature you are requesting is not already in the mod.
+
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: Please give some context for this request. Why do you want it added?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like.
+      description: A clear and concise description of what you want.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered.
+      description: List any alternatives you might have tried to get the feature you want.
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Agreements
+      description: Please agree to the following.
+      options:
+        - label: I have searched for and ensured there isn't already an open issue regarding this.
+          required: true
+        - label: I have ensured the feature I'm requesting isn't already in the latest supported mod version.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Other
+      description: Add any other context or screenshots about the feature request below.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -14,12 +14,14 @@ body:
       description: Please give some context for this request. Why do you want it added?
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Describe the solution you'd like.
       description: A clear and concise description of what you want.
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Describe alternatives you've considered.


### PR DESCRIPTION
These issue templates are based on a couple of the templates found on [PaperMC's main repository.](https://github.com/PaperMC/Paper)