### PR TITLE
ci: fix condition for applying the 'assets' label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,8 +8,7 @@ i18n: '**/assets/*/lang/*'
 
 # Add 'assets' label for changes to assets (except localisation)
 assets:
-  - '**/assets/**/*'
-  - '!**/assets/*/lang/*'
+  - any: ['**/assets/**/*', '!**/assets/*/lang/*']
 
 # Add 'ci' label for changes to the deployment process
 ci:


### PR DESCRIPTION
Changes the label logic for the assets `label` from checking if any file matches any of the conditions, to any file matching all of the conditions.

Fixes #20