### PR TITLE
ci: update the conditions for applying the 'ci' label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,7 +13,8 @@ assets:
 # Add 'ci' label for changes to the deployment process
 ci:
   - '.releaserc*'
-  - '.github/workflows/publish.yml'
+  - any: ['.github/workflows/**/*', '!.github/workflows/build.yml']
+  - '.github/labeler.yml'
 
 # Add 'build' label for changes to the build process
 build:


### PR DESCRIPTION
Expands the set of conditions that automatically receive the `ci` label to include changes to:
- the labeler configuration
- GitHub actions workflows, excluding the build.yml workflow